### PR TITLE
Updated to work with nested objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "unborrow"
-version = "0.1.0"
-authors = ["Alex Burka <aburka@seas.upenn.edu>"]
+version = "0.2.0"
+authors = ["Alex Burka <aburka@seas.upenn.edu>", "David Avedissian <git@davedissian.com>"]
 
 description = "Macro for calling a &mut self method with transient &-borrows of self in the parameters"
 homepage = "https://github.com/durka/unborrow"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,14 +33,14 @@ macro_rules! unborrow {
     // This rule fires when we have parsed all the arguments.
     // It just falls through to output stage.
     // (FIXME could fold the output rule into this one to reduce recursion)
-    (@parse () -> ($names:tt $lets:tt) $($thru:tt)*) => {
-        unborrow!(@out $names $lets $($thru)*)
+    (@parse () -> ($names:tt $lets:tt) $($obj:ident).+) => {
+        unborrow!(@out $names $lets $($obj).+)
     };
 
     // Parse an argument and continue parsing
     // This is the key rule, assigning a name for the argument and generating the let statement.
-    (@parse ($arg:expr, $($rest:tt)*) -> ([$($names:ident),*] [$($lets:stmt);*]) $($thru:tt)*) => {
-        unborrow!(@parse ($($rest)*) -> ([$($names,)* arg] [$($lets;)* let arg = $arg]) $($thru)*)
+    (@parse ($arg:expr, $($rest:tt)*) -> ([$($names:ident),*] [$($lets:stmt);*]) $($obj:ident).+) => {
+        unborrow!(@parse ($($rest)*) -> ([$($names,)* arg] [$($lets;)* let arg = $arg]) $($obj).+)
         //                                            ^                    ^
         // Right here an ident is created out of thin air using hygiene.
         // Every time the macro recurses, we get a new syntax context, so "arg" is actually a new identifier!
@@ -49,17 +49,17 @@ macro_rules! unborrow {
     // Output stage.
     // Assembles the let statements and variable names into a block which computes the arguments,
     // calls the method, and returns its result.
-    (@out [$($names:ident),*] [$($lets:stmt);*] $obj:ident $meth:ident) => {{
+    (@out [$($names:ident),*] [$($lets:stmt);*] $($obj:ident).+) => {{
         $($lets;)*
-        $obj.$meth($($names),*)
+        $($obj).+($($names),*)
     }};
 
     // =========================================================================================================
     // PUBLIC RULES
 
     // Macro entry point.
-    ($obj:ident . $meth:ident ($($args:expr),*)) => {
-        unborrow!(@parse ($($args,)*) -> ([] []) $obj $meth)
+    ($($obj:ident).+ ($($args:expr),*)) => {
+        unborrow!(@parse ($($args,)*) -> ([] []) $($obj).+)
         //                |               |  |   ^ info about the method call, saved for later
         //                |               |  ^ generated let statements
         //                |               ^ generated argument names


### PR DESCRIPTION
The macro in its current form doesn't compile if you have a code fragment such as the following:

``` rust
unborrow!(self.foo.method(self.foo.bar, self.foo.baz));
```

I've modified the macro to be able to deal with any number of "nested objects" by using $(...).+ syntax.
